### PR TITLE
rename foundation foods

### DIFF
--- a/ingredient_parser/dataclasses.py
+++ b/ingredient_parser/dataclasses.py
@@ -183,7 +183,7 @@ class IngredientText:
 
 
 @dataclass
-class FoudationFood:
+class FoundationFood:
     """Dataclass for holding a foundation food string.
 
     This is separate to the IngredientText dataclass so that it can be expanded on
@@ -226,7 +226,7 @@ class ParsedIngredient:
     purpose : IngredientText | None
         The purpose of the ingredient parsed from the sentence.
         If no purpose was found, this is None.
-    foundation_foods : list[FoudationFood]
+    foundation_foods : list[FoundationFood]
         List of foundation foods from the parsed sentence.
     sentence : str
         Normalised input sentence
@@ -238,7 +238,7 @@ class ParsedIngredient:
     preparation: IngredientText | None
     comment: IngredientText | None
     purpose: IngredientText | None
-    foundation_foods: list[FoudationFood]
+    foundation_foods: list[FoundationFood]
     sentence: str
 
     def __post_init__(self):
@@ -282,7 +282,7 @@ class ParserDebugInfo:
     PostProcessor : PostProcessor
         PostProcessor object created using tokens, labels and scores from
         input sentence.
-    foundation_foods : list[FoudationFood]
+    foundation_foods : list[FoundationFood]
         List of foundation foods extracted from parsed ingredient name, or None.
     Tagger : pycrfsuite.Tagger
         CRF model tagger object.
@@ -291,5 +291,5 @@ class ParserDebugInfo:
     sentence: str
     PreProcessor: Any
     PostProcessor: Any
-    foundation_foods: list[FoudationFood]
+    foundation_foods: list[FoundationFood]
     tagger: pycrfsuite.Tagger  # type: ignore

--- a/ingredient_parser/en/_foundationfoods.py
+++ b/ingredient_parser/en/_foundationfoods.py
@@ -8,7 +8,7 @@ from statistics import mean
 import pycrfsuite
 
 from .._common import group_consecutive_idx
-from ..dataclasses import FoudationFood
+from ..dataclasses import FoundationFood
 
 # Create FF_TAGGER object that can be reused between function calls.
 # We only want to load the model into FF_TAGGER once, but only do it
@@ -33,7 +33,7 @@ def load_ffmodel_if_not_loaded():
 
 def join_adjacent_FF_tokens(
     labels: list[str], tokens: list[str], scores: list[float]
-) -> list[FoudationFood]:
+) -> list[FoundationFood]:
     """Join adjacent tokens labelled as FF into strings.
 
     Parameters
@@ -47,7 +47,7 @@ def join_adjacent_FF_tokens(
 
     Returns
     -------
-    list[FoudationFood]
+    list[FoundationFood]
         List of foundation foods
 
     Examples
@@ -67,25 +67,25 @@ def join_adjacent_FF_tokens(
         score = mean([score for _, _, score in group])
 
         foundation_foods.append(
-            FoudationFood(" ".join([tok for _, tok, _ in group]), round(score, 6))
+            FoundationFood(" ".join([tok for _, tok, _ in group]), round(score, 6))
         )
 
     return foundation_foods
 
 
 def deduplicate_foundation_foods(
-    foundation_foods: list[FoudationFood],
-) -> list[FoudationFood]:
+    foundation_foods: list[FoundationFood],
+) -> list[FoundationFood]:
     """Deduplicate foundation foods by averaging the score of duplicates.
 
     Parameters
     ----------
-    foundation_foods : list[FoudationFood]
+    foundation_foods : list[FoundationFood]
         List of foundation foods found in ingredient name.
 
     Returns
     -------
-    list[FoudationFood]
+    list[FoundationFood]
         Description
     """
 
@@ -94,14 +94,14 @@ def deduplicate_foundation_foods(
         seen_foods[ff.text.lower()].append(ff.confidence)
 
     return [
-        FoudationFood(name, mean(confidences))
+        FoundationFood(name, mean(confidences))
         for name, confidences in seen_foods.items()
     ]
 
 
 def extract_foundation_foods(
     tokens: list[str], labels: list[str], features: list[dict[str, str | bool]]
-) -> list[FoudationFood]:
+) -> list[FoundationFood]:
     """Extract foundation foods from tokens labelled as NAME.
 
     Parameters
@@ -115,7 +115,7 @@ def extract_foundation_foods(
 
     Returns
     -------
-    list[FoudationFood]
+    list[FoundationFood]
         List of foundation foods.
     """
     load_ffmodel_if_not_loaded()

--- a/tests/foundationfoods/test_deduplicate_foundation_foods.py
+++ b/tests/foundationfoods/test_deduplicate_foundation_foods.py
@@ -1,18 +1,18 @@
-from ingredient_parser.dataclasses import FoudationFood
+from ingredient_parser.dataclasses import FoundationFood
 from ingredient_parser.en._foundationfoods import deduplicate_foundation_foods
 
 
 class Teste_deduplicate_foundation_foods:
     def test_no_dupes(self):
         ff = [
-            FoudationFood("olive oil", 0.8),
-            FoudationFood("onion", 0.6),
+            FoundationFood("olive oil", 0.8),
+            FoundationFood("onion", 0.6),
         ]
         assert deduplicate_foundation_foods(ff) == ff
 
     def test_dupes(self):
         ff = [
-            FoudationFood("olive oil", 0.8),
-            FoudationFood("olive oil", 0.6),
+            FoundationFood("olive oil", 0.8),
+            FoundationFood("olive oil", 0.6),
         ]
-        assert deduplicate_foundation_foods(ff) == [FoudationFood("olive oil", 0.7)]
+        assert deduplicate_foundation_foods(ff) == [FoundationFood("olive oil", 0.7)]

--- a/tests/foundationfoods/test_join_adjacent_FF_tokens.py
+++ b/tests/foundationfoods/test_join_adjacent_FF_tokens.py
@@ -1,4 +1,4 @@
-from ingredient_parser.dataclasses import FoudationFood
+from ingredient_parser.dataclasses import FoundationFood
 from ingredient_parser.en._foundationfoods import join_adjacent_FF_tokens
 
 
@@ -12,7 +12,7 @@ class TestFF_join_adjacent_FF_tokens:
         scores = [0] * len(tokens)
 
         assert join_adjacent_FF_tokens(labels, tokens, scores) == [
-            FoudationFood("milk", 0),
+            FoundationFood("milk", 0),
         ]
 
     def test_multiple_FF_token(self):
@@ -24,7 +24,7 @@ class TestFF_join_adjacent_FF_tokens:
         scores = [0] * len(tokens)
 
         assert join_adjacent_FF_tokens(labels, tokens, scores) == [
-            FoudationFood("soy milk", 0),
+            FoundationFood("soy milk", 0),
         ]
 
     def test_split_FF_tokens(self):
@@ -36,8 +36,8 @@ class TestFF_join_adjacent_FF_tokens:
         scores = [0] * len(tokens)
 
         assert join_adjacent_FF_tokens(labels, tokens, scores) == [
-            FoudationFood("milk", 0),
-            FoudationFood("soy milk", 0),
+            FoundationFood("milk", 0),
+            FoundationFood("soy milk", 0),
         ]
 
     def test_no_FF_token(self):


### PR DESCRIPTION
This change fixes the typo on Foudation foods. It's a bit confusing if the docs reference Foundation foods but the classes are named Foudation foods instead :)