### PR TITLE
Bugfix: Treat X-inch/Ncm dimensional measurements as size descriptors

### DIFF
--- a/ingredient_parser/en/_constants.py
+++ b/ingredient_parser/en/_constants.py
@@ -182,6 +182,21 @@ SIZES = [
     "tiny",
 ]
 
+# Unit words treated as adjectival size descriptors (not primary measurements)
+# when they appear as the unit of a sole amount in an ingredient.
+DIMENSIONAL_SIZE_UNIT_WORDS = frozenset(
+    {
+        "inch",
+        "inches",
+        "centimeter",
+        "centimeters",
+        "cm",
+        "millimeter",
+        "millimeters",
+        "mm",
+    }
+)
+
 
 # Strings and their numeric representation
 STRING_NUMBERS = {

--- a/ingredient_parser/en/postprocess.py
+++ b/ingredient_parser/en/postprocess.py
@@ -21,6 +21,7 @@ from ..dataclasses import (
 )
 from ._constants import (
     APPROXIMATE_TOKENS,
+    DIMENSIONAL_SIZE_UNIT_WORDS,
     PREPARED_INGREDIENT_TOKENS,
     SINGULAR_TOKENS,
     STOP_WORDS,
@@ -185,6 +186,7 @@ class PostProcessor:
             Object containing structured data from sentence.
         """
         amounts = self._postprocess_amounts()
+        amounts, dimensional_size = self._extract_dimensional_size(amounts)
 
         foundationfoods = []
         if self.separate_names:
@@ -224,6 +226,17 @@ class PostProcessor:
                 name = []
 
         size = self._postprocess("SIZE")
+        if dimensional_size is not None:
+            if size is None:
+                size = dimensional_size
+            else:
+                size = IngredientText(
+                    text=f"{size.text}, {dimensional_size.text}",
+                    confidence=(size.confidence + dimensional_size.confidence) / 2,
+                    starting_index=min(
+                        size.starting_index, dimensional_size.starting_index
+                    ),
+                )
         preparation = self._postprocess("PREP")
         comment = self._postprocess("COMMENT")
         purpose = self._postprocess("PURPOSE")
@@ -723,6 +736,105 @@ class PostProcessor:
             amounts.extend(parsed_amounts)
 
         return sorted(amounts, key=lambda x: x.starting_index)
+
+    # Pluralised dimensional form with a space (e.g. "12 inches cheesecloth")
+    # typically indicates a primary length measurement, not an adjectival size.
+    _PLURAL_DIMENSIONAL_RE = re.compile(
+        r"\b\d+\s+(inches|centimeters|millimeters)\b",
+        re.IGNORECASE,
+    )
+
+    def _is_dimensional_size_amount(
+        self, amt: IngredientAmount | CompositeIngredientAmount
+    ) -> bool:
+        """Return True if *amt* is an :class:`IngredientAmount` whose unit
+        begins with a dimensional size word (inch, centimeter, etc.)."""
+        if isinstance(amt, CompositeIngredientAmount):
+            return False
+
+        unit_str = str(amt.unit).strip().lower()
+        if not unit_str:
+            return False
+
+        return unit_str.split(maxsplit=1)[0] in DIMENSIONAL_SIZE_UNIT_WORDS
+
+    def _extract_dimensional_size(
+        self, amounts: list[IngredientAmount | CompositeIngredientAmount]
+    ) -> tuple[
+        list[IngredientAmount | CompositeIngredientAmount], IngredientText | None
+    ]:
+        """Transform amounts whose unit is a dimensional measurement (inch,
+        centimeter, etc.) into a size descriptor.
+
+        Handles two patterns where the dimensional measurement is semantically
+        the size of a countable ingredient rather than a primary measurement:
+
+        * No leading count (e.g. "6-inch tortilla") -- the dimensional amount
+          is replaced by an implied count of 1 and the dimensional info
+          becomes the size.
+        * Leading count (e.g. "2 6-inch flour tortillas", "1 3-inch piece
+          fresh ginger") -- the count (and any container unit like "piece")
+          is kept as the primary amount and the dimensional component moves
+          to the size.
+
+        Skipped when the sentence uses a pluralised form with a space
+        ("12 inches cheesecloth"), when no NAME token is present, or when
+        no dimensional amount is found.
+
+        Parameters
+        ----------
+        amounts : list[IngredientAmount | CompositeIngredientAmount]
+            Amounts produced by :meth:`_postprocess_amounts`.
+
+        Returns
+        -------
+        tuple
+            ``(modified_amounts, dimensional_size)`` -- a possibly-modified
+            amounts list and an optional size :class:`IngredientText`.
+        """
+        if not amounts:
+            return amounts, None
+
+        if self._PLURAL_DIMENSIONAL_RE.search(self.sentence):
+            return amounts, None
+
+        if not any("NAME" in label for label in self.labels):
+            return amounts, None
+
+        dim_amounts: list[IngredientAmount] = []
+        other_amounts: list[IngredientAmount | CompositeIngredientAmount] = []
+        for amt in amounts:
+            if self._is_dimensional_size_amount(amt):
+                dim_amounts.append(amt)
+            else:
+                other_amounts.append(amt)
+
+        if not dim_amounts:
+            return amounts, None
+
+        size = IngredientText(
+            text=", ".join(a.text for a in dim_amounts),
+            confidence=mean(a.confidence for a in dim_amounts),
+            starting_index=min(a.starting_index for a in dim_amounts),
+        )
+
+        if other_amounts:
+            return other_amounts, size
+
+        first_dim = dim_amounts[0]
+        implied = ingredient_amount_factory(
+            quantity="1",
+            unit="",
+            text="1",
+            confidence=first_dim.confidence,
+            starting_index=first_dim.starting_index,
+            APPROXIMATE=first_dim.APPROXIMATE,
+            string_units=self.string_units,
+            volumetric_units_system=self.volumetric_units_system,
+            custom_units=self.custom_units,
+        )
+
+        return [implied], size
 
     def _unconsumed(self, list_: list[Any]) -> list[Any]:
         """Return elements from list whose index is not in the list of consumed indices.

--- a/tests/parser/test_dimensional_size.py
+++ b/tests/parser/test_dimensional_size.py
@@ -1,0 +1,111 @@
+import pytest
+
+from ingredient_parser import parse_ingredient
+
+
+class TestParser_dimensional_size:
+    @pytest.mark.parametrize(
+        ("sentence", "expected_size_prefix"),
+        [
+            ("6-inch tortilla", "6 inch"),
+            ("5cm cinnamon stick", "5 cm"),
+            ("5 cm cinnamon stick", "5 cm"),
+            ("1 to 2-inch cinnamon stick", "1-2 inch"),
+        ],
+    )
+    def test_no_count(self, sentence, expected_size_prefix):
+        """Dimensional measurement with no leading count produces an implied
+        count of 1 and the measurement becomes a size descriptor."""
+        parsed = parse_ingredient(sentence)
+
+        assert len(parsed.amount) == 1
+        assert parsed.amount[0].quantity == 1
+        assert str(parsed.amount[0].unit) == ""
+        assert parsed.size is not None
+        assert parsed.size.text.startswith(expected_size_prefix)
+
+    @pytest.mark.parametrize(
+        ("sentence", "expected_qty", "expected_unit", "expected_size_prefix"),
+        [
+            ("2 6-inch flour tortillas", 2, "", "6 inch"),
+            ("1 3-inch piece fresh ginger", 1, "piece", "3 inch"),
+            ("1/2-inch piece fresh ginger", 1, "piece", "1/2 inch"),
+        ],
+    )
+    def test_with_non_dimensional_primary(
+        self, sentence, expected_qty, expected_unit, expected_size_prefix
+    ):
+        """A non-dimensional primary amount (count, or count + container unit
+        like "piece") is preserved; only the dimensional component moves to
+        the size descriptor."""
+        parsed = parse_ingredient(sentence)
+
+        assert len(parsed.amount) == 1
+        assert parsed.amount[0].quantity == expected_qty
+        assert str(parsed.amount[0].unit) == expected_unit
+        assert parsed.size is not None
+        assert parsed.size.text.startswith(expected_size_prefix)
+
+    def test_merges_with_size_adjective(self):
+        """A SIZE-labelled adjective and a dimensional measurement both
+        populate the size field, joined by a comma."""
+        parsed = parse_ingredient("large 6-inch tortilla")
+
+        assert parsed.size is not None
+        assert "large" in parsed.size.text
+        assert "inch" in parsed.size.text
+
+
+class TestParser_dimensional_size_not_transformed:
+    """Inputs that must NOT trigger the dimensional-size transformation."""
+
+    @pytest.mark.parametrize(
+        ("sentence", "expected_qty", "expected_unit"),
+        [
+            # Pluralised form with space indicates primary length measurement
+            ("12 inches cheesecloth", 12, "inch"),
+            ("6 inches of fresh ginger", 6, "inch"),
+            # foot/feet excluded (commonly primary length: twine, cheesecloth)
+            ("2 feet butcher twine", 2, "foot"),
+        ],
+    )
+    def test_primary_length_preserved(self, sentence, expected_qty, expected_unit):
+        parsed = parse_ingredient(sentence)
+
+        assert parsed.amount[0].quantity == expected_qty
+        assert str(parsed.amount[0].unit) == expected_unit
+        assert parsed.size is None
+
+    def test_container_pattern_preserved(self):
+        """Compound container patterns produce two structured amounts, not a
+        dimensional-size transformation."""
+        parsed = parse_ingredient("15 ounce can black beans")
+
+        assert len(parsed.amount) == 2
+        assert str(parsed.amount[0].unit) == "can"
+        assert str(parsed.amount[1].unit) == "ounce"
+        assert parsed.size is None
+
+    def test_prep_inch_preserved(self):
+        """Inch used in a preparation phrase (PREP-labelled) is unaffected."""
+        parsed = parse_ingredient("1 pound chicken, cut into 2-inch cubes")
+
+        assert str(parsed.amount[0].unit) == "pound"
+        assert parsed.size is None
+        assert parsed.preparation is not None
+
+    def test_parenthesized_dimensional_preserved(self):
+        """Parenthesized dimensional forms go through the COMMENT path and
+        are not transformed."""
+        parsed = parse_ingredient("5 (8 inch) flour tortillas")
+
+        assert len(parsed.amount) == 1
+        assert parsed.amount[0].quantity == 5
+
+    def test_size_adjective_preserved(self):
+        """SIZE-labelled adjectives on non-dimensional inputs are unaffected."""
+        parsed = parse_ingredient("3 large eggs")
+
+        assert parsed.amount[0].quantity == 3
+        assert parsed.size is not None
+        assert parsed.size.text == "large"

--- a/tests/postprocess/test_extract_dimensional_size.py
+++ b/tests/postprocess/test_extract_dimensional_size.py
@@ -1,0 +1,56 @@
+from ingredient_parser.en import PostProcessor
+from ingredient_parser.en._utils import ingredient_amount_factory
+
+
+class TestPostProcessor_extract_dimensional_size:
+    def test_skips_when_no_name_tokens(self):
+        """Without a NAME token the dimensional measurement is more likely a
+        primary measurement, so the transformation is skipped."""
+        amounts = [
+            ingredient_amount_factory(
+                quantity="6",
+                unit="inch",
+                text="6 inches",
+                confidence=0.9,
+                starting_index=0,
+            ),
+        ]
+        p = PostProcessor(
+            "6-inch",
+            ["6", "inch"],
+            ["CD", "NN"],
+            ["QTY", "UNIT"],
+            [0.9] * 2,
+            custom_units={},
+        )
+        result_amounts, size = p._extract_dimensional_size(amounts)
+
+        assert result_amounts == amounts
+        assert size is None
+
+    def test_transforms_multi_word_dimensional_unit(self):
+        """When the fallback pattern joins multiple UNIT tokens into a single
+        amount (e.g. "inches strips"), the transformation still recognises
+        the leading dimensional word."""
+        amounts = [
+            ingredient_amount_factory(
+                quantity="3",
+                unit="inches strips",
+                text="3 inches strips",
+                confidence=0.9,
+                starting_index=0,
+            ),
+        ]
+        p = PostProcessor(
+            "3-inch strip lemon zest",
+            ["3", "inch", "strip", "lemon", "zest"],
+            ["CD", "NN", "NN", "NN", "NN"],
+            ["QTY", "UNIT", "UNIT", "B_NAME_TOK", "I_NAME_TOK"],
+            [0.9] * 5,
+            custom_units={},
+        )
+        result_amounts, size = p._extract_dimensional_size(amounts)
+
+        assert len(result_amounts) == 1
+        assert result_amounts[0].quantity == 1
+        assert size.text == "3 inches strips"


### PR DESCRIPTION
## Problem

When an ingredient sentence uses a dimensional unit (inch, cm, mm) to describe
the size of a countable item, the parser currently treats the measurement as a
primary amount. This produces semantically wrong output:

```python
>>> parse_ingredient("6-inch tortilla")
# amount[0]: qty=6, unit="inch"      <-- WRONG (can't have 6 inches of 1 tortilla)
# size: None
# name: tortilla

>>> parse_ingredient("2-inch cinnamon stick")
# amount[0]: qty=2, unit="inch"      <-- WRONG
# size: None
```

With a leading count, the dimensional info is preserved as a secondary amount
rather than populating the `size` field, which is less useful for downstream
consumers that want the structured count separately from the size descriptor:

```python
>>> parse_ingredient("2 6-inch flour tortillas")
# amount[0]: qty=2, unit=""
# amount[1]: qty=6, unit="inch"      <-- size info in secondary amount
# size: None
```

## Root cause

The CRF correctly labels `6-inch` as `[QTY, UNIT=inch, ...]` (and similarly for
cm/mm), but the postprocessor has no mechanism to recognise a dimensional
measurement as a size descriptor rather than a primary quantity.

Preparation phrases like `cut into 2-inch cubes` are unaffected because the
CRF already labels those tokens as PREP, not UNIT.

## Fix

Postprocessor-only change, no model retraining required. Adds a new method
`_extract_dimensional_size` that runs after amount parsing and transforms
dimensional measurements into the `size` field:

* **No leading count** (e.g. `"6-inch tortilla"`): the dimensional amount is
  replaced by an implied count of 1 and the dimensional info becomes `size`.
* **Leading count** (e.g. `"2 6-inch flour tortillas"`, `"1 3-inch piece
  fresh ginger"`): the count (and any container unit like `piece`) is kept
  as the primary amount; the dimensional component moves to `size`.

```python
>>> parse_ingredient("6-inch tortilla")
# amount[0]: qty=1, unit=""
# size: "6 inches"
# name: tortilla

>>> parse_ingredient("2 6-inch flour tortillas")
# amount[0]: qty=2, unit=""
# size: "6 inches"
# name: flour tortillas

>>> parse_ingredient("1 3-inch piece fresh ginger")
# amount[0]: qty=1, unit="piece"
# size: "3 inches"
# name: fresh ginger
```

## Guard rails

Three preconditions block the transformation to avoid regressing legitimate
primary-length measurements:

1. **Pluralised form with space** in the original sentence (e.g.
   `"12 inches cheesecloth"`, `"6 inches of fresh ginger"`) typically
   describes a primary length, not an adjectival size. Matched by
   `_PLURAL_DIMENSIONAL_RE`.
2. **No NAME token** -- there is no ingredient being described.
3. **No dimensional amount in the result** -- nothing to transform.

`foot`/`feet` are deliberately excluded from the dimensional unit set because
they are more commonly used for real primary measurements (butcher twine,
cheesecloth).

## Note on scope

The no-leading-count case (`"6-inch tortilla"`) is clearly a bug -- `qty=6,
unit=inch` for a single tortilla is nonsensical.

The leading-count case (`"2 6-inch flour tortillas"`) is a semantic
improvement -- the previous output wasn't strictly wrong, just less useful
(dimensional info in a secondary amount rather than the `size` field).

Both are handled together in this PR because the transformation logic is
shared. If you'd prefer to scope down to just the no-count case, the
`if other_amounts:` branch in `_extract_dimensional_size` can be dropped
cleanly. Happy to split if preferred.

## Testing

All existing tests pass, plus 17 new tests covering the transformation,
guard rails, and regression patterns (container compound units, parenthesized
dimensional forms, PREP phrases, SIZE adjectives, foot/feet exclusion, and
pluralised primary-length forms).

```python
>>> parse_ingredient("15 ounce can black beans")  # PR #49 behaviour
# amount[0]: qty=1, unit="can"
# amount[1]: qty=15, unit="ounce"

>>> parse_ingredient("12 inches cheesecloth")     # primary length preserved
# amount[0]: qty=12, unit="inch"

>>> parse_ingredient("1 pound chicken, cut into 2-inch cubes")  # PREP unchanged
# amount[0]: qty=1, unit="pound"
# preparation: "cut into 2 inch cubes"
```

---
*This fix was developed with support from [Claude Code](https://claude.ai/code).
Genuine effort has been made to test and validate the quality and accuracy of
this change in order to be respectful of the project maintainer's time and
effort. Feedback on what could be done better in this regard is always
welcomed.*