### PR TITLE
Improve PREPARED_INGREDIENT accuracy for irreversible-prep verbs at volumetric amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### develop
 
+* Improve `PREPARED_INGREDIENT` accuracy for irreversible-prep verbs at volumetric amounts. Sentences like `1 cup carrots, diced` or `1 cup pecans, halved` now correctly set `PREPARED_INGREDIENT=True`. The syntactic rule (preparation position relative to amount and name) previously produced `False` for the post-comma form regardless of verb, but pre-prep volumetric measurement is physically impossible for irreversible action verbs (chopped, sliced, diced, minced, grated, shredded, etc.). The override only fires for non-liquid-only volumetric units (cup, tbsp, tsp, pint, quart, gallon) where prep changes the measurable volume; it does not fire for count or mass units, strict-liquid units (ml, cl, dl, l, fl oz), or for reversible-order verbs like `sifted` and `packed` where the syntactic rule remains correct. (@[MaximusCub](https://github.com/MaximusCub))
 * Bugfix: `PreProcessor` no longer treats lean-grade percentage ratios (e.g. `80/20`, `85/15`, `93/7`; all sum to 100) as fractions. They now pass through tokenization as separate tokens (`80`, `/`, `20`) rather than being collapsed into a single `#X$Y` form. (@[MaximusCub](https://github.com/MaximusCub))
 * Label trailing "raw" tokens after a comma as preparation instructions instead of part of the ingredient name. Affects USDA-style descriptions like "93% lean ground beef, raw". (@[MaximusCub](https://github.com/MaximusCub))
 * Handle "X ounce can" compound unit pattern without leading count (@[MaximusClub](https://github.com/MaximusCub))

--- a/docs/source/explanation/postprocessing.rst
+++ b/docs/source/explanation/postprocessing.rst
@@ -301,8 +301,17 @@ IngredientAmount flags
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
 | **PREPARED_INGREDIENT** | This is set to True when the amount refers to the ingredient after any preparation instructions in the ingredient sentence have been followed.      |
 |                         |                                                                                                                                                     |
-|                         | For example in the sentence **1 tbsp chopped nuts**, we would want 1 tablespoon of nuts, measured after they have been chopped.                     |
-|                         | If the sentence was **1 tbsp nuts, chopped**, we would want to chop the nuts after we have measured 1 tablespoon.                                   |
+|                         | The flag is determined by two heuristics. The primary rule is syntactic: when the preparation appears between the amount and the name               |
+|                         | (e.g. **1 cup sifted flour**) the amount measures the prepared form and the flag is True; when the preparation trails the name                      |
+|                         | (e.g. **1 cup flour, sifted**) the amount measures the unprepared form and the flag is False.                                                       |
+|                         |                                                                                                                                                     |
+|                         | The syntactic rule is overridden for irreversible action verbs (chopped, sliced, diced, minced, grated, shredded, etc.) when the amount unit         |
+|                         | is volumetric (cup, tbsp, tsp, pint, quart, gallon). For these combinations pre-prep volumetric measurement is physically impossible                |
+|                         | (you cannot cup-measure unchopped onion or unshredded cheese), so the amount must measure the prepared form and the flag is forced True             |
+|                         | regardless of preparation position. The override does not fire for strict-liquid units (ml, cl, dl, l, fl oz) where volume is preserved             |
+|                         | through preparation, nor for count or mass units where the measurement is invariant under preparation.                                              |
+|                         |                                                                                                                                                     |
+|                         | The full set of irreversible verbs is defined in ``ingredient_parser.en._constants.IRREVERSIBLE_PREP_VERBS``.                                       |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
 
 

--- a/docs/source/tutorials/examples.rst
+++ b/docs/source/tutorials/examples.rst
@@ -135,6 +135,12 @@ For example, **1 cup flour, sifted** instructs the chef to measure 1 cup of flou
 Conversely, **1 cup sifted flour** instructs the chef to sift flour to obtain 1 cup, which would have a different mass to the first case.
 For this second case, the ``PREPARED_INGREDIENT`` flag will be set to True.
 
+This syntactic rule is overridden when the preparation is an irreversible action verb (chopped, sliced, diced, minced, grated, shredded, etc.) and the amount unit is volumetric.
+For these combinations pre-prep volumetric measurement is physically impossible — there is no way to cup-measure unchopped onion or unshredded cheese — so the amount must refer to the prepared form regardless of preparation position.
+The override does not fire for strict-liquid units (ml, cl, dl, l, fl oz), or for count and mass units where the measurement is invariant under preparation.
+
+For example, **1 cup carrots, diced** sets ``PREPARED_INGREDIENT`` to True (the cup measures diced carrots, since pre-dice cup measurement is impossible), while **3 carrots, diced** keeps it False (the count of three whole carrots is unchanged by subsequent dicing).
+
 .. code:: python
 
     >>> parse_ingredient("1 cup flour, sifted")

--- a/ingredient_parser/en/_constants.py
+++ b/ingredient_parser/en/_constants.py
@@ -427,6 +427,63 @@ PREPARED_INGREDIENT_TOKENS = [
     ["to", "make"],
 ]
 
+# Action verbs that irreversibly transform an ingredient's physical form
+# such that pre-prep volumetric measurement is impossible (you cannot
+# measure a cup of an unchopped onion or unshredded cheese block). When a
+# sentence contains a PREP-labelled token from this set and the amount
+# unit is volumetric, the PREPARED_INGREDIENT flag is forced True
+# regardless of the syntactic position of the preparation. Excludes
+# reversible-order verbs like "sifted" and "packed" where pre-prep
+# measurement is genuinely possible, and excludes state adjectives like
+# "frozen" or "dried" that describe procurement form rather than a
+# post-measurement action.
+IRREVERSIBLE_PREP_VERBS = {
+    "chopped",
+    "cored",
+    "crumbled",
+    "crushed",
+    "cubed",
+    "deveined",
+    "diced",
+    "drained",
+    "grated",
+    "ground",
+    "halved",
+    "hulled",
+    "julienned",
+    "mashed",
+    "minced",
+    "pitted",
+    "pureed",
+    "quartered",
+    "seeded",
+    "shredded",
+    "sliced",
+    "slivered",
+    "smashed",
+    "snipped",
+}
+
+# Volumetric units that exclusively measure liquids in cooking contexts.
+# Pint dimensionality lumps liquid and dry volumes together, but for the
+# IRREVERSIBLE_PREP_VERBS override we only want to fire on units where
+# pre-prep volumetric measurement is genuinely impossible (the
+# physically-can't-cup-measure-unchopped-cheese case). For strictly
+# liquid units, the unprepped form is just as measurable as the prepped
+# form, the workflow reading "measure first then prep" is the natural
+# interpretation of comma-trailing prep, and the volume is preserved
+# through prep so the flag value is informationally minor anyway.
+# Excluding these keeps the override scoped to the cases where it
+# materially changes downstream density-conversion correctness.
+LIQUID_ONLY_UNIT_NAMES = {
+    "centiliter",
+    "deciliter",
+    "fluid_ounce",
+    "liter",
+    "milliliter",
+}
+
+
 # List of sets, where each set contains the synonyms that represent the same unit.
 UNIT_SYNONYMS = [
     {"cup", "c"},

--- a/ingredient_parser/en/_utils.py
+++ b/ingredient_parser/en/_utils.py
@@ -15,6 +15,7 @@ from .._common import UREG, consume, download_nltk_resources, is_float, is_range
 from ..dataclasses import IngredientAmount
 from ._constants import (
     FLATTENED_UNITS_LIST,
+    LIQUID_ONLY_UNIT_NAMES,
     UNIT_SYNONYMS,
     UNITS,
 )
@@ -364,6 +365,93 @@ def convert_to_pint_unit(
         return UREG(unit).units
 
     return unit
+
+
+def _coerce_unit_to_pint(unit: pint.Unit | str | list[str] | None) -> pint.Unit | None:
+    """Normalise the three forms an amount unit can take across the
+    parser pipeline (pint.Unit, str, list[str]) to a pint.Unit.
+
+    Returns None if the input is empty or cannot be resolved by pint.
+    String / list inputs are routed through convert_to_pint_unit so
+    hyphen edge cases, MISINTERPRETED_UNITS and the standard
+    unit-string replacements are handled consistently with the rest of
+    the pipeline.
+    """
+    if unit is None or unit == "":
+        return None
+
+    if isinstance(unit, list):
+        unit = " ".join(unit).strip()
+        if not unit:
+            return None
+
+    if isinstance(unit, str):
+        unit = convert_to_pint_unit(unit)
+
+    if isinstance(unit, pint.Unit):
+        return unit
+
+    return None
+
+
+def is_volumetric_unit(unit: pint.Unit | str | list[str] | None) -> bool:
+    """Return True if the given unit measures volume.
+
+    Detection is delegated to pint by comparing dimensionality against
+    UREG.cup. Accepts the three unit forms used across the parser
+    pipeline: pint.Unit, str, and list[str] (raw partial-amount form).
+
+    Parameters
+    ----------
+    unit : pint.Unit | str | list[str] | None
+        Unit value from a partial or full IngredientAmount.
+
+    Returns
+    -------
+    bool
+        True if the unit's dimensionality matches volume, otherwise False.
+        Empty / unknown units return False.
+    """
+    pu = _coerce_unit_to_pint(unit)
+    if pu is None:
+        return False
+    try:
+        return pu.dimensionality == UREG.cup.dimensionality
+    except (pint.errors.UndefinedUnitError, pint.errors.DimensionalityError):
+        return False
+
+
+def is_liquid_only_unit(unit: pint.Unit | str | list[str] | None) -> bool:
+    """Return True if the given unit exclusively measures liquids in
+    cooking contexts (ml, cl, dl, l, fl oz and their aliases).
+
+    Pint dimensionality treats all volume units as equivalent, but for
+    cooking semantics we sometimes need to distinguish strictly-liquid
+    units from dual-use volumetric units (cup, tbsp, tsp, pint, quart,
+    gallon) that commonly measure both liquids and dry ingredients.
+    The IRREVERSIBLE_PREP_VERBS override uses this distinction:
+    pre-prep measurement is physically possible for liquids regardless
+    of preparation, so the override only fires on volumetric units that
+    are not strictly liquid.
+
+    Accepts the same input forms as is_volumetric_unit.
+
+    Parameters
+    ----------
+    unit : pint.Unit | str | list[str] | None
+        Unit value from a partial or full IngredientAmount.
+
+    Returns
+    -------
+    bool
+        True if the unit is one of the strictly-liquid volumetric units
+        (members of LIQUID_ONLY_UNIT_NAMES). Empty / unknown units
+        return False.
+    """
+    pu = _coerce_unit_to_pint(unit)
+    if pu is None:
+        return False
+    return str(pu) in LIQUID_ONLY_UNIT_NAMES
 
 
 @lru_cache(maxsize=512)

--- a/ingredient_parser/en/postprocess.py
+++ b/ingredient_parser/en/postprocess.py
@@ -23,6 +23,7 @@ from ._constants import (
     APPROXIMATE_PREFIXES,
     APPROXIMATE_SUFFIXES,
     INDEFINITE_QUANTIFIERS,
+    IRREVERSIBLE_PREP_VERBS,
     PREPARED_INGREDIENT_TOKENS,
     SINGULAR_TOKENS,
     STOP_WORDS,
@@ -32,6 +33,8 @@ from ._regex import FRACTION_TOKEN_PATTERN
 from ._utils import (
     combine_quantities_split_by_and,
     ingredient_amount_factory,
+    is_liquid_only_unit,
+    is_volumetric_unit,
     pluralise_units,
     replace_string_range,
 )
@@ -1346,6 +1349,18 @@ class PostProcessor:
                 if prepared:
                     first_amount.PREPARED_INGREDIENT = True
                     second_amount.PREPARED_INGREDIENT = True
+                elif self._has_irreversible_prep_verb() and (
+                    (
+                        is_volumetric_unit(first_amount.unit)
+                        and not is_liquid_only_unit(first_amount.unit)
+                    )
+                    or (
+                        is_volumetric_unit(second_amount.unit)
+                        and not is_liquid_only_unit(second_amount.unit)
+                    )
+                ):
+                    first_amount.PREPARED_INGREDIENT = True
+                    second_amount.PREPARED_INGREDIENT = True
 
                 composite_amounts.append(
                     CompositeIngredientAmount(
@@ -1544,6 +1559,29 @@ class PostProcessor:
 
             if self._is_prepared(i, tokens):
                 amounts[-1].PREPARED_INGREDIENT = True
+
+        # Verb-class override: when the sentence contains an irreversible
+        # action prep verb (chopped, sliced, etc.) and the amount unit is
+        # volumetric but not strictly liquid-only (ml/cl/dl/l/fl_oz),
+        # force PREPARED_INGREDIENT True regardless of the syntactic
+        # position of the preparation. The syntactic rule in
+        # ParsedIngredient.set_prepared_flag handles reversible-order
+        # verbs like "sifted" correctly, but produces False for
+        # irreversible verbs in the `1 cup carrots, diced` shape where
+        # pre-prep volumetric measurement is physically impossible.
+        # Strict-liquid units are excluded because pre-prep measurement
+        # is physically possible for liquids and volume is preserved
+        # through prep, so the workflow reading dominates. This
+        # refinement only flips False to True; it never overrides an
+        # existing True.
+        if self._has_irreversible_prep_verb():
+            for amount in amounts:
+                if (
+                    not amount.PREPARED_INGREDIENT
+                    and is_volumetric_unit(amount.unit)
+                    and not is_liquid_only_unit(amount.unit)
+                ):
+                    amount.PREPARED_INGREDIENT = True
 
         # Set APPROXIMATE, SINGULAR and PREPARED_INGREDIENT flags to be the same for all
         # related amounts.
@@ -1857,6 +1895,30 @@ class PostProcessor:
                 self.consumed.append(tokens[i - 3].index)
                 return True
 
+        return False
+
+    def _has_irreversible_prep_verb(self) -> bool:
+        """Return True if any PREP-labelled token in the sentence is an
+        irreversible action verb (chopped, sliced, diced, etc.) — one
+        that physically transforms the ingredient such that pre-prep
+        volumetric measurement is impossible.
+
+        Multi-word PREP tokens are split on whitespace and hyphens so
+        that compound forms like "thinly-sliced" or "finely chopped"
+        register as containing the irreversible head verb.
+
+        Returns
+        -------
+        bool
+            True if any PREP token contains an irreversible action verb.
+        """
+        for tok in self.tokens:
+            if tok.label != "PREP":
+                continue
+            for part in re.split(r"[\s\-]+", tok.text.lower()):
+                cleaned = part.strip(".,;:()'\"")
+                if cleaned in IRREVERSIBLE_PREP_VERBS:
+                    return True
         return False
 
     def _distribute_related_flags(

--- a/tests/parser/test_prepared_ingredient.py
+++ b/tests/parser/test_prepared_ingredient.py
@@ -46,3 +46,117 @@ class Test_prepared_ingredient:
         parsed = parse_ingredient(sentence)
         for amount in parsed.amount:
             assert amount.PREPARED_INGREDIENT
+
+    def test_irreversible_prep_volumetric(self):
+        """
+        Irreversible prep verb after a comma with a volumetric unit:
+        pre-prep cup measurement is physically impossible, so the amount
+        must measure the prepared form.
+        """
+        sentence = "1 cup carrots, diced"
+        parsed = parse_ingredient(sentence)
+        assert len(parsed.amount) > 0
+        for amount in parsed.amount:
+            assert amount.PREPARED_INGREDIENT
+
+    def test_irreversible_prep_volumetric_pair(self):
+        """
+        Override propagates across paired metric/imperial amounts via
+        _distribute_related_flags. The override fires only on the cup
+        (volumetric) but the gram (mass) gets True via propagation.
+        """
+        sentence = "1 cup (140 g) onion, finely chopped"
+        parsed = parse_ingredient(sentence)
+        assert len(parsed.amount) == 2
+        for amount in parsed.amount:
+            assert amount.PREPARED_INGREDIENT
+
+    def test_irreversible_prep_count_unit(self):
+        """
+        Override does not fire for count units. The count of whole
+        ingredients is invariant under prep.
+        """
+        sentence = "3 carrots, diced"
+        parsed = parse_ingredient(sentence)
+        assert len(parsed.amount) > 0
+        for amount in parsed.amount:
+            assert not amount.PREPARED_INGREDIENT
+
+    def test_irreversible_prep_mass_unit(self):
+        """
+        Override does not fire for mass units. Mass is preserved through
+        irreversible prep so the flag is unchanged from the syntactic
+        rule.
+        """
+        sentence = "1 lb chicken, cubed"
+        parsed = parse_ingredient(sentence)
+        assert len(parsed.amount) > 0
+        for amount in parsed.amount:
+            assert not amount.PREPARED_INGREDIENT
+
+    def test_irreversible_prep_hyphenated(self):
+        """
+        Hyphenated PREP tokens (`thinly-sliced`) are split on hyphens so
+        the irreversible head verb is still detected.
+        """
+        sentence = "1 cup carrots, thinly-sliced"
+        parsed = parse_ingredient(sentence)
+        assert len(parsed.amount) > 0
+        for amount in parsed.amount:
+            assert amount.PREPARED_INGREDIENT
+
+    def test_irreversible_prep_liquid_only_unit(self):
+        """
+        Override does not fire for strict-liquid volumetric units
+        (ml, cl, dl, l, fl oz). Liquid volume is preserved through prep
+        so the syntactic rule's False is the natural reading.
+        """
+        sentence = "10 ml olive oil, drained"
+        parsed = parse_ingredient(sentence)
+        assert len(parsed.amount) > 0
+        for amount in parsed.amount:
+            assert not amount.PREPARED_INGREDIENT
+
+    def test_irreversible_prep_drained_volumetric(self):
+        """
+        `drained` produces a measurably different volume on solid /
+        semi-solid ingredients (drained yogurt, drained beans). For
+        non-liquid-only volumetric units the override correctly flips
+        True.
+        """
+        sentence = "1 cup yogurt, drained"
+        parsed = parse_ingredient(sentence)
+        assert len(parsed.amount) > 0
+        for amount in parsed.amount:
+            assert amount.PREPARED_INGREDIENT
+
+    def test_irreversible_prep_composite_amount(self):
+        """
+        The override has a separate fire site in
+        _composite_amounts_pattern for lb+oz / pt+floz patterns. Verify
+        a composite of pint+fl_oz with an irreversible verb flips both
+        component amounts to True even though the fl_oz component alone
+        is liquid-only.
+        """
+        sentence = "1 pint 3 fl oz tomatoes, diced"
+        parsed = parse_ingredient(sentence)
+        assert len(parsed.amount) > 0
+        composite = parsed.amount[0]
+        assert hasattr(composite, "amounts")
+        assert len(composite.amounts) == 2
+        for sub_amount in composite.amounts:
+            assert sub_amount.PREPARED_INGREDIENT
+
+    def test_excluded_verb_does_not_fire_override(self):
+        """
+        Pin the contract that verbs deliberately excluded from
+        IRREVERSIBLE_PREP_VERBS (state adjectives, time-process verbs,
+        reversible-order verbs) do not trigger the override even on
+        volumetric units. Guards against accidental additions to the
+        set that would silently change behavior.
+        """
+        sentence = "1 cup rice, cooked"
+        parsed = parse_ingredient(sentence)
+        assert len(parsed.amount) > 0
+        for amount in parsed.amount:
+            assert not amount.PREPARED_INGREDIENT


### PR DESCRIPTION
## Summary

Fixes `PREPARED_INGREDIENT` returning the wrong value for sentences where an irreversible action verb (chopped, sliced, diced, etc.) trails a comma at a volumetric amount.

```
>>> parse_ingredient("1 cup carrots, diced").amount[0].PREPARED_INGREDIENT
False  # on develop today

>>> parse_ingredient("1 cup diced carrots").amount[0].PREPARED_INGREDIENT
True
```

Both sentences describe the same thing -- 1 cup of diced carrots -- but the flag flips on word order alone. That behavior is correct for genuinely two-way verbs like `sifted` (where `1 cup flour, sifted` and `1 cup sifted flour` are physically different quantities), but produces the wrong answer for verbs where pre-prep volumetric measurement is physically impossible.

## Root cause

`PREPARED_INGREDIENT` is set by syntactic position in `ParsedIngredient.set_prepared_flag`: prep-between-amount-and-name -> True, prep-after-name -> False, plus the `to yield`/`to make` heuristic. The flour/sifted contrast that motivates this rule is genuinely two-way, but it's a corner case in real recipes. For most prep verbs (chopped, sliced, diced, minced, grated, shredded, etc.) you cannot cup-measure the unprepped form -- there is no way to put unchopped onion or unshredded cheese into a cup measure -- so the post-comma form must measure the prepared form regardless of word order.

## Approach

A postprocessor fix, no CRF retrain. The CRF correctly tags the verbs as `PREP`; only the post-CRF flag interpretation needs to change.

- A closed list of 24 irreversible action verbs (`IRREVERSIBLE_PREP_VERBS`)
- Fires only when the amount unit is volumetric AND not strictly liquid-only -- `LIQUID_ONLY_UNIT_NAMES = {centiliter, deciliter, fluid_ounce, liter, milliliter}` excluded because pre-prep liquid measurement is physically possible and volume is preserved through prep
- Only flips False to True; never overrides an existing True (positional or yield/make)
- Reversible-order verbs (`sifted`, `packed`) and state adjectives (`frozen`, `dried`) remain excluded

## Changes

- `ingredient_parser/en/_constants.py` -- `IRREVERSIBLE_PREP_VERBS` (24) and `LIQUID_ONLY_UNIT_NAMES` (5)
- `ingredient_parser/en/_utils.py` -- public predicates `is_volumetric_unit(unit)` and `is_liquid_only_unit(unit)` delegated to pint dimensionality, plus a shared `_coerce_unit_to_pint` helper
- `ingredient_parser/en/postprocess.py` -- `_has_irreversible_prep_verb()` method, override sites in `_fallback_pattern` and `_composite_amounts_pattern`. Runs before `_distribute_related_flags` so paired metric/imperial amounts (`1 cup (140 g) onion, finely chopped`) propagate correctly.
- `tests/parser/test_prepared_ingredient.py` -- 9 new tests covering canonical positive, paired propagation, count/mass/strict-liquid gates, hyphenated PREP token, composite path, and a negative case (`1 cup rice, cooked` stays False) pinning the exclusion of adjacent verbs
- `docs/source/explanation/postprocessing.rst` -- replaces the existing `1 tbsp chopped nuts` / `1 tbsp nuts, chopped` worked example with prose covering both the syntactic rule and the verb-class override
- `docs/source/tutorials/examples.rst` -- adds a paragraph after the flour/sifted archetype contrasting volumetric/count/mass behavior under the override
- `CHANGELOG.md` -- entry under `### develop`

7 files, 339 insertions / 2 deletions.

## Validation

Full test suite green (466 passed). The 5 existing prepared-ingredient tests pass unchanged.

Corpus measurement: parsed every sentence in `train/data/training.sqlite3` matching the SQL pattern below across all 24 verbs (1086 unique sentences after dedup; 1130 raw matches), once with the override and once with the override reverted to origin/develop:

```sql
SELECT sentence FROM en
WHERE LOWER(sentence) GLOB '*[0-9]* {unit}*, {verb}*'
   OR LOWER(sentence) GLOB '*[0-9]* {unit}*, {verb}'
-- where {unit} in {cup, tablespoon, tbsp, tbs, teaspoon, tsp, pint, quart, gallon}
-- and {verb} in IRREVERSIBLE_PREP_VERBS
```

| | `PREPARED_INGREDIENT=True` count |
|---|---:|
| origin/develop (no override) | 192 |
| this PR (with override) | 1042 |
| **flipped False -> True by the override** | **850** |

10 random rows sampled from the 850 flipped sentences:

```
1 tablespoon sliced pimientos, chopped
1/2 cup artichoke hearts, drained and chopped (optional)
1/3 cup onions, chopped
1/2 cup oil-packed sun-dried tomatoes, drained and diced
2 tablespoons drained bottled capers, chopped
1 tablespoon thyme leaves, chopped
2 cups canned Italian plum tomatoes, with their juice, chopped
1 cup fresh basil leaves, chopped
1/2 cup porcini mushrooms, chopped (if dried, 1/4 cup)
1/2 cup sweet pickles, diced with some juice from the jar
```

In most sampled cases the natural reading appears to be form-at-measurement (1/3 cup of chopped onions, 1 cup of chopped fresh basil leaves, etc.). The hypothetical "measure first, then prep as a workflow step" reading isn't expressed in this syntactic shape -- when writers want that they use a different form entirely.

A subset is genuinely borderline: herbs in particular (`1 cup fresh basil leaves, chopped`, `1 tablespoon thyme leaves, chopped`) can reasonably mean either "measure whole leaves, then chop" or "chop, then measure" -- whole leaves are themselves cup-measurable, unlike whole onions or unshredded cheese, so the workflow reading isn't physically excluded the way it is for the canonical cases. This is accepted as a minor cost. For a use case that may commonly be served by the flag -- volumetric-to-mass density conversion for nutrition / calorie mapping -- a misclassification on a tablespoon of herbs has small mass and calorie consequences relative to correctly resolving the bulk-ingredient cases (chopped onions, diced carrots, shredded cheese, halved cherry tomatoes, etc.) where the unprepped and prepped forms differ in mass by 25-100%.

## Why the verb list is shaped this way

Pre-comma vs post-comma frequency at volumetric units across the 24 verbs (same SQL pattern, swapping `'*[0-9]* {unit}*, {verb}*'` for `'*[0-9]* {unit}* {verb} *'` for the pre-comma count):

| verb | pre-comma | post-comma |
|---|---:|---:|
| chopped | 3,011 | 290 |
| ground | 1,151 | 32 |
| grated | 827 | 21 |
| minced | 780 | 79 |
| sliced | 451 | 61 |
| shredded | 364 | 34 |
| diced | 329 | 62 |
| crushed | 245 | 88 |
| drained | 161 | 179 |
| pitted | 120 | 45 |
| crumbled | 77 | 32 |
| halved | 33 | 32 |
| seeded | 57 | 42 |
| cored | 29 | 35 |
| (10 others, smaller) | | |

For pre-comma-dominant verbs (chopped, ground, grated, minced), writers prefer the explicit `cup VERB X` syntax when meaning form-at-measurement; the post-comma form is rarer but means the same thing. For near-equal pre/post ratios (halved, quartered, cored, drained, seeded), writers use both forms interchangeably.

Deliberately excluded from the verb list: state adjectives (`frozen`, `dried`, `chilled`, `refrigerated`), reversible-order preps (`sifted`, `packed`, `melted`, `softened`), and time-process verbs (`cooked`, `boiled`, `roasted`, `toasted`) where the syntactic rule remains correct or where corpus inspection shows the post-comma form is genuinely ambiguous.

## Notes

A CRF-shaped solution is possible -- splitting `PREP` into sub-labels for irreversible vs reversible-order verbs in the corpus, then keying the flag off the new label -- but it felt like meaningful added complexity (re-labelling and retraining for a property that's a flat per-verb attribute) for little practical gain over the postprocessor approach. The postprocessor route seemed the most elegant fit: the CRF is already correctly identifying these tokens as `PREP`, the bug is purely in how that signal is interpreted into the flag, and a closed verb-class set captures it directly. Open to redoing as a CRF change if you prefer; the verb list and corpus survey above would feed the labelling pass.
